### PR TITLE
Added ability to give the individual curl calls a key to look up on. This fixes issue #3

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -12,16 +12,29 @@ Move mcurl.php to your libraries folder. To view the examples in your applicatio
 	
 	$this->load->library('mcurl');
 	
-	// add_call( METHOD, URL, array of PARAMS, array of CURL_OPTS )
-	$this->mcurl->add_call("get","http://google.com");
-	$this->mcurl->add_call("post","http://twitter.com");
-	$this->mcurl->add_call("get","http://google.com",array("q"=>"codeigniter"));
-	$this->mcurl->add_call("get","https://facebook.com",array(),array(CURLOPT_SSL_VERIFYPEER => FALSE));
+	// add_call( KEY, METHOD, URL, array of PARAMS, array of CURL_OPTS )
+	$this->mcurl->add_call("call1","get","http://google.com");
+	$this->mcurl->add_call("call2","post","http://twitter.com");
+	$this->mcurl->add_call("call3","get","http://google.com",array("q"=>"codeigniter"));
+	$this->mcurl->add_call("call4","get","https://facebook.com",array(),array(CURLOPT_SSL_VERIFYPEER => FALSE));
 	
 	// execute the calls
 	$responses = $this->mcurl->execute();
 	
-	// show some debugging
+	// retrieve a specific call by key
+	// this will return the response of the google.com request
+	$response = $this->mcurl->calls["call1"]["response"];
+	
+	// available data to use
+	$this->mcurl->calls["key"]["method"]; // the method POST/GET used in request
+	$this->mcurl->calls["key"]["url"]; // the uri of the request
+	$this->mcurl->calls["key"]["params"]; // the data parameters sent in request
+	$this->mcurl->calls["key"]["options"]; // the curl options used in the request
+	$this->mcurl->calls["key"]["curl"]; // the php curl object
+	$this->mcurl->calls["key"]["response"]; // the response of the request
+	$this->mcurl->calls["key"]["error"]; // if not null, there are some errors
+	
+	// show some debugging on all calls
 	$this->mcurl->debug();
 	
 

--- a/application/controllers/example.php
+++ b/application/controllers/example.php
@@ -1,59 +1,59 @@
 <?php
 
 class Example extends CI_Controller {
-    
-    function __construct()
-    {
-        parent::__construct();
-    }
-    
-    function index()
-    {
-        /*
-        ** Load the mcurl library
-        */
-        $this->load->library('mcurl');
+	
+	function __construct()
+	{
+		parent::__construct();
+	}
+	
+	function index()
+	{
+		/*
+		** Load the mcurl library
+		*/
+		$this->load->library('mcurl');
 
-        /*
-        ** Example 1: Adding a Basic GET Request
-        */
-        $this->mcurl->add_call("call1","get","http://chadhutchins.com");
+		/*
+		** Example 1: Adding a Basic GET Request
+		*/
+		$this->mcurl->add_call("call1","get","http://chadhutchins.com");
 
-        /*
-        ** Example 2: Adding a Basic POST Request
-        */
-        $this->mcurl->add_call("call2","post","http://twitter.com/chadhutchins");
+		/*
+		** Example 2: Adding a Basic POST Request
+		*/
+		$this->mcurl->add_call("call2","post","http://twitter.com/chadhutchins");
 
-        /*
-        ** Example 3: Adding a more complex Request with Variables and Curl Options
-        */
-        $vars = array(
-            "v" => "1.0",
-            "q" => "blogHer"
-        );
+		/*
+		** Example 3: Adding a more complex Request with Variables and Curl Options
+		*/
+		$vars = array(
+			"v" => "1.0",
+			"q" => "blogHer"
+		);
 
-        $options = array(
-            CURLOPT_SSL_VERIFYPEER => FALSE
-        );
+		$options = array(
+			CURLOPT_SSL_VERIFYPEER => FALSE
+		);
 
-        $this->mcurl->add_call("call3","get","https://ajax.googleapis.com/ajax/services/search/blogs",$vars,$options);
+		$this->mcurl->add_call("call3","get","https://ajax.googleapis.com/ajax/services/search/blogs",$vars,$options);
 
-        /*
-        ** Example 4: Error Handling
-        */
-        $this->mcurl->add_call("call4","post","httpasdf://twitter.com/chadhutchins");
+		/*
+		** Example 4: Error Handling
+		*/
+		$this->mcurl->add_call("call4","post","httpasdf://twitter.com/chadhutchins");
 
-        /*
-        ** Execute the requests with Multiple Curl
-        */
-        $data = $this->mcurl->execute();
+		/*
+		** Execute the requests with Multiple Curl
+		*/
+		$data = $this->mcurl->execute();
 
-        /*
-        ** Display the results with debug method
-        */
-        $this->mcurl->debug();
-    }
-    
+		/*
+		** Display the results with debug method
+		*/
+		$this->mcurl->debug();
+	}
+	
 }
 
 ?>

--- a/application/controllers/example.php
+++ b/application/controllers/example.php
@@ -17,12 +17,12 @@ class Example extends CI_Controller {
         /*
         ** Example 1: Adding a Basic GET Request
         */
-        $this->mcurl->add_call("get","http://chadhutchins.com");
+        $this->mcurl->add_call("call1","get","http://chadhutchins.com");
 
         /*
         ** Example 2: Adding a Basic POST Request
         */
-        $this->mcurl->add_call("post","http://twitter.com/chadhutchins");
+        $this->mcurl->add_call("call2","post","http://twitter.com/chadhutchins");
 
         /*
         ** Example 3: Adding a more complex Request with Variables and Curl Options
@@ -36,12 +36,12 @@ class Example extends CI_Controller {
             CURLOPT_SSL_VERIFYPEER => FALSE
         );
 
-        $this->mcurl->add_call("get","https://ajax.googleapis.com/ajax/services/search/blogs",$vars,$options);
+        $this->mcurl->add_call("call3","get","https://ajax.googleapis.com/ajax/services/search/blogs",$vars,$options);
 
         /*
         ** Example 4: Error Handling
         */
-        $this->mcurl->add_call("post","httpasdf://twitter.com/chadhutchins");
+        $this->mcurl->add_call("call4","post","httpasdf://twitter.com/chadhutchins");
 
         /*
         ** Execute the requests with Multiple Curl
@@ -52,7 +52,6 @@ class Example extends CI_Controller {
         ** Display the results with debug method
         */
         $this->mcurl->debug();
-        
     }
     
 }

--- a/application/libraries/mcurl.php
+++ b/application/libraries/mcurl.php
@@ -62,8 +62,13 @@ class Mcurl {
     }
 
     // method to add curl requests to the multi request queue
-    function add_call($method, $url, $params = array(), $options = array())
+    function add_call($key=null, $method, $url, $params = array(), $options = array())
     {
+		if (is_null($key))
+		{
+			$key = count($this->calls);
+		}
+		
         // check to see if the multi handle has been closed
         // init the multi handle again
         $resource_type = get_resource_type($this->curl_parent);
@@ -73,9 +78,7 @@ class Mcurl {
             $this->curl_parent = curl_multi_init();
         }
 
-        $call_count = count($this->calls);
-
-        $this->calls [$call_count]= array(
+        $this->calls [$key]= array(
             "method" => $method,
             "url" => $url,
             "params" => $params,
@@ -85,7 +88,7 @@ class Mcurl {
             "error" => null
         );
 
-        $this->calls[$call_count]["curl"] = curl_init();
+        $this->calls[$key]["curl"] = curl_init();
 
         // If its an array (instead of a query string) then format it correctly
         if (is_array($params))
@@ -100,13 +103,13 @@ class Mcurl {
         switch ($method)
         {	        
             case "POST":
-                curl_setopt($this->calls[$call_count]["curl"], CURLOPT_URL, $url);
-                curl_setopt($this->calls[$call_count]["curl"], CURLOPT_POST, TRUE);
-                curl_setopt($this->calls[$call_count]["curl"], CURLOPT_POSTFIELDS, $params);
+                curl_setopt($this->calls[$key]["curl"], CURLOPT_URL, $url);
+                curl_setopt($this->calls[$key]["curl"], CURLOPT_POST, TRUE);
+                curl_setopt($this->calls[$key]["curl"], CURLOPT_POSTFIELDS, $params);
                 break;
 
             case "GET":
-                curl_setopt($this->calls[$call_count]["curl"], CURLOPT_URL, $url."?".$params);
+                curl_setopt($this->calls[$key]["curl"], CURLOPT_URL, $url."?".$params);
                 break;
 
             default:
@@ -114,12 +117,12 @@ class Mcurl {
                 break;
         }
 
-        curl_setopt($this->calls[$call_count]["curl"], CURLOPT_RETURNTRANSFER, TRUE);
-        curl_setopt($this->calls[$call_count]["curl"], CURLOPT_FOLLOWLOCATION, TRUE);
+        curl_setopt($this->calls[$key]["curl"], CURLOPT_RETURNTRANSFER, TRUE);
+        curl_setopt($this->calls[$key]["curl"], CURLOPT_FOLLOWLOCATION, TRUE);
 
-        curl_setopt_array($this->calls[$call_count]["curl"], $options);
+        curl_setopt_array($this->calls[$key]["curl"], $options);
 
-        curl_multi_add_handle($this->curl_parent,$this->calls[$call_count]["curl"]);        
+        curl_multi_add_handle($this->curl_parent,$this->calls[$key]["curl"]);        
     }
 
     // run the calls in the curl requests in $this->calls

--- a/application/libraries/mcurl.php
+++ b/application/libraries/mcurl.php
@@ -27,146 +27,146 @@ THE SOFTWARE.
  *
  * Work with remote servers via multi-cURL much easier than using the native PHP bindings.
  *
- * @package         CodeIgniter
- * @subpackage      Libraries
- * @category        Libraries
- * @author          Chad Hutchins
- * @link            http://github.com/chadhutchins/codeigniter-mcurl
+ * @package			CodeIgniter
+ * @subpackage		Libraries
+ * @category		Libraries
+ * @author			Chad Hutchins
+ * @link			http://github.com/chadhutchins/codeigniter-mcurl
  */
  
 class Mcurl {
 
-    private $_ci;               // CodeIgniter instance
-    private $calls = array();   // multidimensional array that holds individual calls and data
-    private $curl_parent;       // the curl multi handle resource
+	private $_ci;				// CodeIgniter instance
+	private $calls = array();	// multidimensional array that holds individual calls and data
+	private $curl_parent;		// the curl multi handle resource
 
-    function __construct()
-    {
-        $this->_ci = & get_instance();
-        log_message('debug', 'Mcurl Class Initialized');
+	function __construct()
+	{
+		$this->_ci = & get_instance();
+		log_message('debug', 'Mcurl Class Initialized');
 
-        if (!$this->is_enabled())
-        {
-            log_message('error', 'Mcurl Class - PHP was not built with cURL enabled. Rebuild PHP with --with-curl to use cURL.');
-        }
-        else 
-        {
-            $this->curl_parent = curl_multi_init();
-        }
-    }
+		if (!$this->is_enabled())
+		{
+			log_message('error', 'Mcurl Class - PHP was not built with cURL enabled. Rebuild PHP with --with-curl to use cURL.');
+		}
+		else 
+		{
+			$this->curl_parent = curl_multi_init();
+		}
+	}
 
-    // check to see if necessary function exists
-    function is_enabled()
-    {
-        return function_exists('curl_multi_init');
-    }
+	// check to see if necessary function exists
+	function is_enabled()
+	{
+		return function_exists('curl_multi_init');
+	}
 
-    // method to add curl requests to the multi request queue
-    function add_call($key=null, $method, $url, $params = array(), $options = array())
-    {
+	// method to add curl requests to the multi request queue
+	function add_call($key=null, $method, $url, $params = array(), $options = array())
+	{
 		if (is_null($key))
 		{
 			$key = count($this->calls);
 		}
 		
-        // check to see if the multi handle has been closed
-        // init the multi handle again
-        $resource_type = get_resource_type($this->curl_parent);
-        if(!$resource_type || $resource_type == 'Unknown')
-        {
-            $this->calls = array();
-            $this->curl_parent = curl_multi_init();
-        }
+		// check to see if the multi handle has been closed
+		// init the multi handle again
+		$resource_type = get_resource_type($this->curl_parent);
+		if(!$resource_type || $resource_type == 'Unknown')
+		{
+			$this->calls = array();
+			$this->curl_parent = curl_multi_init();
+		}
 
-        $this->calls [$key]= array(
-            "method" => $method,
-            "url" => $url,
-            "params" => $params,
-            "options" => $options,
-            "curl" => null,
-            "response" => null,
-            "error" => null
-        );
+		$this->calls [$key]= array(
+			"method" => $method,
+			"url" => $url,
+			"params" => $params,
+			"options" => $options,
+			"curl" => null,
+			"response" => null,
+			"error" => null
+		);
 
-        $this->calls[$key]["curl"] = curl_init();
+		$this->calls[$key]["curl"] = curl_init();
 
-        // If its an array (instead of a query string) then format it correctly
-        if (is_array($params))
-        {
-            $params = http_build_query($params, NULL, '&');
-        }
+		// If its an array (instead of a query string) then format it correctly
+		if (is_array($params))
+		{
+			$params = http_build_query($params, NULL, '&');
+		}
 
-        $method = strtoupper($method);
-        
-        // only supports get/post requests
-        // set some special curl opts for each type of request
-        switch ($method)
-        {	        
-            case "POST":
-                curl_setopt($this->calls[$key]["curl"], CURLOPT_URL, $url);
-                curl_setopt($this->calls[$key]["curl"], CURLOPT_POST, TRUE);
-                curl_setopt($this->calls[$key]["curl"], CURLOPT_POSTFIELDS, $params);
-                break;
+		$method = strtoupper($method);
+		
+		// only supports get/post requests
+		// set some special curl opts for each type of request
+		switch ($method)
+		{			
+			case "POST":
+				curl_setopt($this->calls[$key]["curl"], CURLOPT_URL, $url);
+				curl_setopt($this->calls[$key]["curl"], CURLOPT_POST, TRUE);
+				curl_setopt($this->calls[$key]["curl"], CURLOPT_POSTFIELDS, $params);
+				break;
 
-            case "GET":
-                curl_setopt($this->calls[$key]["curl"], CURLOPT_URL, $url."?".$params);
-                break;
+			case "GET":
+				curl_setopt($this->calls[$key]["curl"], CURLOPT_URL, $url."?".$params);
+				break;
 
-            default:
-                log_message('error', 'Mcurl Class - Provided http method is not supported. Only POST and GET are currently supported.');
-                break;
-        }
+			default:
+				log_message('error', 'Mcurl Class - Provided http method is not supported. Only POST and GET are currently supported.');
+				break;
+		}
 
-        curl_setopt($this->calls[$key]["curl"], CURLOPT_RETURNTRANSFER, TRUE);
-        curl_setopt($this->calls[$key]["curl"], CURLOPT_FOLLOWLOCATION, TRUE);
+		curl_setopt($this->calls[$key]["curl"], CURLOPT_RETURNTRANSFER, TRUE);
+		curl_setopt($this->calls[$key]["curl"], CURLOPT_FOLLOWLOCATION, TRUE);
 
-        curl_setopt_array($this->calls[$key]["curl"], $options);
+		curl_setopt_array($this->calls[$key]["curl"], $options);
 
-        curl_multi_add_handle($this->curl_parent,$this->calls[$key]["curl"]);        
-    }
+		curl_multi_add_handle($this->curl_parent,$this->calls[$key]["curl"]);		 
+	}
 
-    // run the calls in the curl requests in $this->calls
-    function execute()
-    {
-        if (count($this->calls))
-        {
-            // kick off the requests
-            do
-            {
-                $multi_exec_handle = curl_multi_exec($this->curl_parent,$active);
-            } while ($active>0);
+	// run the calls in the curl requests in $this->calls
+	function execute()
+	{
+		if (count($this->calls))
+		{
+			// kick off the requests
+			do
+			{
+				$multi_exec_handle = curl_multi_exec($this->curl_parent,$active);
+			} while ($active>0);
 
-            // after all requests finish, set errors and repsonses in $this->calls
-            foreach ($this->calls as $key => $call)
-            {
-                $error = curl_error($this->calls[$key]["curl"]);
-                if (!empty($error))
-                {
-                    $this->calls[$key]["error"] = $error;
-                }
-                $this->calls[$key]["response"] = curl_multi_getcontent($this->calls[$key]["curl"]);
-                curl_multi_remove_handle($this->curl_parent,$this->calls[$key]["curl"]);
-            }
+			// after all requests finish, set errors and repsonses in $this->calls
+			foreach ($this->calls as $key => $call)
+			{
+				$error = curl_error($this->calls[$key]["curl"]);
+				if (!empty($error))
+				{
+					$this->calls[$key]["error"] = $error;
+				}
+				$this->calls[$key]["response"] = curl_multi_getcontent($this->calls[$key]["curl"]);
+				curl_multi_remove_handle($this->curl_parent,$this->calls[$key]["curl"]);
+			}
 
-            curl_multi_close($this->curl_parent);
-        }
+			curl_multi_close($this->curl_parent);
+		}
 
-        return $this->calls;
-    }
-    
-    function debug()
-    {
-        echo "<h2>mcurl debug</h2>";
-        foreach ($this->calls as $call)
-        {
-            echo '<p>url: <b>'.$call["url"].'</b></p>';
-            if (!is_null($call["error"]))
-            {
-                echo '<p style="color:red;">error: <b>'.$call["error"].'</b></p>';
-            }
-            echo '<textarea cols="100" rows="10">'.htmlentities($call["response"])."</textarea><hr>";
-        }
-    }
+		return $this->calls;
+	}
+	
+	function debug()
+	{
+		echo "<h2>mcurl debug</h2>";
+		foreach ($this->calls as $call)
+		{
+			echo '<p>url: <b>'.$call["url"].'</b></p>';
+			if (!is_null($call["error"]))
+			{
+				echo '<p style="color:red;">error: <b>'.$call["error"].'</b></p>';
+			}
+			echo '<textarea cols="100" rows="10">'.htmlentities($call["response"])."</textarea><hr>";
+		}
+	}
 
 }
 


### PR DESCRIPTION
Before, it was difficult to pull out a response of a single curl request. You had to keep up with the calls array count yourself to know which request was where. Now, the first parameter of add_calls is the $key. So at any point you can look up an individual curl request by its key.
